### PR TITLE
Add new ChatRoom design

### DIFF
--- a/uMatriks/ChatRoom.qml
+++ b/uMatriks/ChatRoom.qml
@@ -1,14 +1,13 @@
 import QtQuick 2.4
 import Ubuntu.Components 1.3
 import Matrix 1.0
+import "components"
 //import Qt.labs.settings 1.0
 import 'jschat.js' as JsChat
 
 
 Rectangle {
     id: root
-//    color: Theme.chatBg
-//    color: "#fdf6e3"
 
     property Connection currentConnection: null
     property var currentRoom: null
@@ -43,97 +42,27 @@ Rectangle {
         anchors.fill: parent
         flickableDirection: Flickable.VerticalFlick
         verticalLayoutDirection: ListView.BottomToTop
+        spacing: units.gu(2)
         model: MessageEventModel { id: messageModel }
 
-        delegate: Row {
-            id: message
+
+        delegate: ChatBubble {
+            id: chatBubble
             width: parent.width
-            spacing: 8
-
-//            Image{
-//                source: "logo.png"
-////                source: eventType == "message" ? author: avatar
-//                width: units.gu(3)
-//                height: units.gu(3)
-
-//            }
-
-            Column{
-                Label {
-                    id: timelabel
-                    text: time.toLocaleTimeString("hh:mm")
-                    color: "grey"
-                    width: units.gu(6)
-                    //                font.pointSize: Theme.timeLabelSize
-                    font.pointSize: units.gu(0.9)
-                    horizontalAlignment: Text.AlignRight
-                }
-                Label {
-                    id: authorlabel
-                    width: units.gu(6)
-                    elide: Text.ElideRight
-                    text: eventType == "message" ? author : "***"
-                    //                font.family: Theme.nickFont
-                    font.family: "Consolas"
-                    font.pointSize: units.gu(0.9)
-                    color: eventType == "message" ? JsChat.NickColoring.get(author): "lightgrey"
-                    horizontalAlignment: Text.AlignRight
-                }
-            }
-            Label {
-                id: contentlabel
-                text: content
-                wrapMode: Text.Wrap
-                width: parent.width - (x - parent.x) - spacing
-                color: eventType == "message" ? "black" : "lightgrey"
-                linkColor: "black"
-                textFormat: Text.RichText
-//                font.family: Theme.textFont
-                font.family:"Ubuntumono"
-//                font.pointSize: Theme.textSize
-                font.pointSize: units.gu(1.5)
-                onLinkActivated: Qt.openUrlExternally(link)
-                function checkForImgLink()
-                {
-                    contentlabel.height = contentlabel.height + units.gu(3);
-                    if(text.search("http") != -1 && (text.search(".png") != -1 || text.search(".jpg") != -1 || text.search(".gif") != -1))
-                    {
-                        var start = text.search("http");
-                        var end;
-                        var media;
-                        if(text.search(".gif") != -1)
-                        {
-                            end = text.search(".gif");
-                            media = Qt.createQmlObject('import QtQuick 2.4; AnimatedImage {}', contentlabel);
-                        }
-                        else
-                        {
-                            end = text.search(".png") != -1 ? text.search(".png") : text.search(".jpg");
-                            media = Qt.createQmlObject('import QtQuick 2.4; Image {}', contentlabel);
-                        }
-                        var url = text.slice(start, end + 4);
-                        console.log(url);
-                        media.source = url;
-                        media.y = contentlabel.height;
-                        media.height = units.gu(30);
-                        media.width = contentlabel.width;
-                        media.fillMode = Image.PreserveAspectFit;
-                        contentlabel.height = contentlabel.height + units.gu(33);
-                    }
-                }
-                Component.onCompleted: checkForImgLink();
-            }
+            connection: currentConnection
+            room: currentRoom
         }
 
 
+        /*
         section {
             property: "date"
             labelPositioning: ViewSection.CurrentLabelAtStart
             delegate: Rectangle {
+                id: dateRect
                 width: parent.width
                 height: childrenRect.height
-                //color: Theme.chatBg
-//                color: "#fdf6e3"
+                anchors.top: chatBubble.bottom
                 Label {
                     width: parent.width
                     text: status + " " + section.toLocaleString(Qt.locale())
@@ -142,18 +71,16 @@ Rectangle {
                 }
             }
         }
+        */
 
         onAtYBeginningChanged: {
             if(currentRoom && atYBeginning) currentRoom.getPreviousContent(50)
         }
 
-//        ScrollBar.vertical: ScrollBar {
         Scrollbar {
             id: scrollBar
-//            stepSize: chatView.visibleArea.heightRatio / 3
             align: Qt.AlignTrailing
         }
-
 
     }
 }

--- a/uMatriks/Main.qml
+++ b/uMatriks/Main.qml
@@ -109,6 +109,7 @@ MainView {
 
             header: PageHeader{
                 id:pageHeader
+
                 title: i18n.tr("[ uMatriks ]")
                             StyleHints {
                                 foregroundColor: UbuntuColors.jet
@@ -213,7 +214,6 @@ MainView {
     Login {
         id: login
         anchors.fill: parent
-//            visible: false
         Component.onCompleted: {
             var user = settings.user
             var token = settings.token

--- a/uMatriks/RoomView.qml
+++ b/uMatriks/RoomView.qml
@@ -100,25 +100,42 @@ Flickable {
 
     ChatRoom {
         id: chat
-        anchors.bottom: textEntry.top
+        anchors.bottom: textRect.top
         anchors.right: parent.right
         anchors.left: parent.left
         anchors.top: parent.top
+        anchors.margins: {
+            bottom: 20
+        }
     }
 
 
-    TextField {
-        id: textEntry
+    Rectangle {
+        id: textRect
         anchors.right: parent.right
         anchors.left: parent.left
         anchors.bottom: parent.bottom
-        focus: true
+        color: "white"
 
-        placeholderText: qsTr("Say something...")
-        onAccepted: sendLine(text)
+        TextField {
+            id: textEntry
+            focus: true
+            anchors.right: parent.right
+            anchors.left: parent.left
+            anchors.bottom: parent.bottom
+            anchors.margins: 10
 
-        Keys.onBacktabPressed: onKeyPressed(event, true)
-        Keys.onPressed: onKeyPressed(event, false)
+
+            placeholderText: qsTr("Say something...")
+            onAccepted: sendLine(text)
+
+            Keys.onBacktabPressed: onKeyPressed(event, true)
+            Keys.onPressed: onKeyPressed(event, false)
+
+            Component.onCompleted: {
+                textRect.height = height + (anchors.margins * 2);
+            }
+        }
     }
 }
 

--- a/uMatriks/components/ChatBubble.qml
+++ b/uMatriks/components/ChatBubble.qml
@@ -1,0 +1,167 @@
+import QtQuick 2.0
+import Ubuntu.Components 1.3
+import Matrix 1.0
+import '../jschat.js' as JsChat
+
+Item {
+    id: chatBubble
+
+    height: Math.max(avatarIcon.height, rect.height)
+
+
+    property Connection connection: null
+    property var room: null
+
+    Rectangle {
+        id: avatarIcon
+        height: units.gu(6)
+        anchors.top: chatBubble.top
+        width: height
+        radius: 10
+        anchors.margins: 15
+        clip: true
+
+        Image {
+            id: avatarImg
+            anchors.fill: parent
+        }
+    }
+
+    Rectangle {
+        id: rect
+        anchors.top: chatBubble.top
+        anchors.margins: {
+            right: 20
+            left: 20
+        }
+        border.color: "grey"
+        border.width: 1
+        radius: 10
+
+            Text {
+                id: contentlabel
+                text: content
+                wrapMode: Text.Wrap
+                font.pointSize: units.gu(1.5)
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.margins: 15
+                color: "white"
+                linkColor: "black"
+                textFormat: Text.RichText
+                onLinkActivated: Qt.openUrlExternally(link)
+            }
+
+            Image {
+                id: contentImage
+                visible: false
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.margins: 15
+                fillMode: Image.PreserveAspectFit
+                height: units.gu(20)
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            AnimatedImage {
+                id: contentAnimatedImage
+                visible: false
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.margins: 15
+                fillMode: Image.PreserveAspectFit
+                height: units.gu(20)
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            Row {
+                id: innerRect
+                anchors.left: parent.left
+                anchors.bottom: parent.bottom
+                anchors.margins: 5
+
+                Text {
+                    id: timelabel
+                    text: time.toLocaleTimeString("hh:mm")
+                    font.pointSize: units.gu(0.9)
+                }
+                Text {
+                    text: " - "
+                    font.pointSize: units.gu(0.9)
+                }
+                Text {
+                    id: authorlabel
+                    text: eventType == "message" ? author : "***"
+                    font.pointSize: units.gu(0.9)
+                }
+            }
+
+            function checkForImgLink()
+            {
+                if (msgType === "image") {
+                    contentImage.source = content;
+                    contentImage.visible = true;
+                    content.visable = false;
+                }
+
+                var cont;
+
+                if (content.search("https://") != -1)
+                    cont = content.replace("https://", "http://");
+                else
+                    cont = content;
+
+                if(cont.search("http://") != -1 && (cont.search(".png") != -1 || cont.search(".jpg") != -1 || cont.search(".gif") != -1))
+                {
+                    var start = cont.search("http://");
+                    var end;
+                    var url;
+                    if(content.search(".gif") != -1)
+                    {
+                        end = cont.search(".gif");
+                        url = cont.slice(start, end + 4);
+                        contentAnimatedImage.source = url;
+                        contentAnimatedImage.visible = true;
+                        contentAnimatedImage.anchors.top = contentlabel.bottom;
+                        rect.height += contentAnimatedImage.height;
+                    }
+                    else
+                    {
+                        end = cont.search(".png") != -1 ? cont.search(".png") : cont.search(".jpg");
+                        url = cont.slice(start, end + 4);
+                        contentImage.source = url;
+                        contentImage.visible = true;
+                        contentImage.anchors.top = contentlabel.bottom;
+                        rect.height += contentImage.height;
+                    }
+                }
+            }
+
+
+            Component.onCompleted: {
+                contentlabel.width = Math.min(contentlabel.contentWidth, chatBubble.width - avatarIcon.width - 40 - 30)
+                contentlabel.height = contentlabel.contentHeight
+
+                width = Math.max(contentlabel.width, innerRect.width) + 30
+                height = Math.max(contentlabel.height + innerRect.height + 40, avatarIcon.height)
+
+                checkForImgLink();
+            }
+    }
+
+    Component.onCompleted: {
+        if (avatar) {
+            avatarImg.source = avatar;
+        }
+
+        if (userId === connection.userId()) {
+            avatarIcon.anchors.right = chatBubble.right
+            rect.anchors.right = avatarIcon.left
+            rect.color = "#2ecc71"
+        } else {
+            avatarIcon.anchors.left = chatBubble.left
+            rect.anchors.left = avatarIcon.right
+            rect.color = "#bdc3c7"
+        }
+    }
+}

--- a/uMatriks/models/messageeventmodel.h
+++ b/uMatriks/models/messageeventmodel.h
@@ -38,7 +38,10 @@ class MessageEventModel: public QAbstractListModel
             TimeRole,
             DateRole,
             AuthorRole,
-            ContentRole
+            ContentRole,
+            UserIdRole,
+            AvatarRole,
+            MsgTypeRole
         };
 
         MessageEventModel(QObject* parent=0);

--- a/uMatriks/uMatriks.qrc
+++ b/uMatriks/uMatriks.qrc
@@ -10,5 +10,6 @@
         <file>RoomView.qml</file>
         <file>Theme.qml</file>
         <file>umatriks.svg</file>
+        <file>components/ChatBubble.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This add a new ChatRoom design.

The new ChatRoom design, includes:

- Messages in "bubbles"
- Avatars
- Display images and gif

In progress:

- Display "EventContents", this includes images, text, emote etc.
- Download "EventContents"

![umat](https://user-images.githubusercontent.com/1642635/29000118-54dfd4b8-7a62-11e7-8598-191848ad45fd.png)

Gif and image:
![ugif](https://user-images.githubusercontent.com/1642635/29000140-22039498-7a63-11e7-80e6-a90ee92e1eb4.png)
