### PR TITLE
Add support for showing images and do not show events in a chat bubble

### DIFF
--- a/uMatriks/ChatRoom.qml
+++ b/uMatriks/ChatRoom.qml
@@ -3,7 +3,7 @@ import Ubuntu.Components 1.3
 import Matrix 1.0
 import "components"
 //import Qt.labs.settings 1.0
-import 'jschat.js' as JsChat
+//import 'jschat.js' as JsChat
 
 
 Rectangle {
@@ -49,7 +49,6 @@ Rectangle {
         delegate: ChatBubble {
             id: chatBubble
             width: parent.width
-            connection: currentConnection
             room: currentRoom
         }
 

--- a/uMatriks/Main.qml
+++ b/uMatriks/Main.qml
@@ -27,7 +27,6 @@ MainView {
     signal joinedRoom(string room)
     signal leaveRoom(var room)
 
-    Connection { id: connection }
     Settings   {
         id: settings
 

--- a/uMatriks/components/ChatBubble.qml
+++ b/uMatriks/components/ChatBubble.qml
@@ -1,15 +1,13 @@
 import QtQuick 2.0
 import Ubuntu.Components 1.3
 import Matrix 1.0
-import '../jschat.js' as JsChat
+//import '../jschat.js' as JsChat
 
 Item {
     id: chatBubble
 
     height: Math.max(avatarIcon.height, rect.height)
 
-
-    property Connection connection: null
     property var room: null
 
     Rectangle {
@@ -18,7 +16,7 @@ Item {
         anchors.top: chatBubble.top
         width: height
         radius: 10
-        anchors.margins: 15
+        anchors.margins: 20
         clip: true
 
         Image {
@@ -60,6 +58,7 @@ Item {
                 anchors.margins: 15
                 fillMode: Image.PreserveAspectFit
                 height: units.gu(20)
+                width:  height
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 
@@ -98,11 +97,6 @@ Item {
 
             function checkForImgLink()
             {
-                if (msgType === "image") {
-                    contentImage.source = content;
-                    contentImage.visible = true;
-                    content.visable = false;
-                }
 
                 var cont;
 
@@ -139,29 +133,58 @@ Item {
 
 
             Component.onCompleted: {
-                contentlabel.width = Math.min(contentlabel.contentWidth, chatBubble.width - avatarIcon.width - 40 - 30)
-                contentlabel.height = contentlabel.contentHeight
-
-                width = Math.max(contentlabel.width, innerRect.width) + 30
-                height = Math.max(contentlabel.height + innerRect.height + 40, avatarIcon.height)
-
-                checkForImgLink();
+                if (eventType == "message"){
+                    if (msgType === "image"){
+                        contentImage.width = chatBubble.width - avatarIcon.width - 40 - 30
+                        width = Math.max(contentImage.width, innerRect.width) + 30
+                        height = Math.max(contentImage.height + innerRect.height + 40, avatarIcon.height)
+                    }   else {
+                        contentlabel.width = Math.min(contentlabel.contentWidth, chatBubble.width - avatarIcon.width - 40 - 30)
+                        contentlabel.height = contentlabel.contentHeight
+                        width = Math.max(contentlabel.width, innerRect.width) + 30
+                        height = Math.max(contentlabel.height + innerRect.height + 40, avatarIcon.height)
+                        checkForImgLink();
+                    }
+                }
             }
     }
 
     Component.onCompleted: {
-        if (avatar) {
-            avatarImg.source = avatar;
-        }
+        if (eventType == "message"){
 
-        if (userId === connection.userId()) {
-            avatarIcon.anchors.right = chatBubble.right
-            rect.anchors.right = avatarIcon.left
-            rect.color = "#2ecc71"
+            if (avatar) {
+                avatarImg.source = avatar;
+            }
+
+            if (userId === connection.userId()) {
+                avatarIcon.anchors.right = chatBubble.right
+                rect.anchors.right = avatarIcon.left
+                rect.color = "#2ecc71"
+            } else {
+                avatarIcon.anchors.left = chatBubble.left
+                rect.anchors.left = avatarIcon.right
+                rect.color = "#bdc3c7"
+            }
+
+            if (msgType === "image") {
+                contentImage.sourceSize = "1000x1000"
+                contentImage.source = content;
+                contentImage.visible = true;
+                contentlabel.visible = false;
+            }
         } else {
-            avatarIcon.anchors.left = chatBubble.left
-            rect.anchors.left = avatarIcon.right
-            rect.color = "#bdc3c7"
+            innerRect.visible = false
+            avatarIcon.visible = false
+            rect.color = "white"
+            rect.border.width = 0
+            contentlabel.color = UbuntuColors.graphite;
+            contentlabel.font.pointSize = units.gu(0.9)
+            contentlabel.width = contentlabel.contentWidth
+            contentlabel.height = contentlabel.contentHeight
+            rect.height = contentlabel.contentHeight
+            rect.width = contentlabel.width;
+            rect.anchors.horizontalCenter = horizontalCenter
+            height = rect.height + 20
         }
     }
 }

--- a/uMatriks/main.cpp
+++ b/uMatriks/main.cpp
@@ -11,6 +11,7 @@
 #include "jobs/leaveroomjob.h"
 #include "models/messageeventmodel.h"
 #include "models/roomlistmodel.h"
+#include "models/imageprovider.h"
 #include "settings.h"
 using namespace QMatrixClient;
 
@@ -34,8 +35,6 @@ int main(int argc, char *argv[])
     }
 
     QQmlApplicationEngine engine;
-//    engine.addImportPath("./lib/arm-linux-gnueabihf/QtQuick/Controls");
-//    engine.addImportPath("./lib/arm-linux-gnueabihf/QtQuick/Dialogs");
     view.connect(&engine, SIGNAL(quit()), &app, SLOT(quit()));
     new QQmlFileSelector(view.engine(), &view);
 
@@ -45,6 +44,11 @@ int main(int argc, char *argv[])
     qmlRegisterType<LeaveRoomJob>();qRegisterMetaType<LeaveRoomJob*> ("LeaveRoomJob*");
     qmlRegisterType<Room>();        qRegisterMetaType<Room*>    ("Room*");
     qmlRegisterType<User>();        qRegisterMetaType<User*>    ("User*");
+
+    Connection* conn = new Connection();
+    ImageProvider* img = new ImageProvider(conn);
+    view.engine()->rootContext()->setContextProperty("connection", conn);
+    view.engine()->addImageProvider("mtx", img);
 
     qmlRegisterType<Connection>        ("Matrix", 1, 0, "Connection");
     qmlRegisterType<MessageEventModel> ("Matrix", 1, 0, "MessageEventModel");

--- a/uMatriks/models/avatarprovider.cpp
+++ b/uMatriks/models/avatarprovider.cpp
@@ -1,0 +1,14 @@
+#include "avatarprovider.h"
+#include "lib/connection.h"
+#include <QQuickImageProvider>
+
+AvatarProvider::AvatarProvider(QMatrixClient::Connection* conn)
+    : QQuickAsyncImageProvider(QQuickAsyncImageProvider::Pixmap),
+      connection(conn)
+{
+}
+
+AvatarProvider::requestPixmap(const QString &id, QSize *size, const QSize &requestedSize)
+{
+
+}

--- a/uMatriks/models/avatarprovider.h
+++ b/uMatriks/models/avatarprovider.h
@@ -1,0 +1,18 @@
+#include <QQuickImageProvider>
+#include "lib/connection.h"
+
+#ifndef AVATARPROVIDER_H
+#define AVATARPROVIDER_H
+
+
+class AvatarProvider : public QQuickImageProvider
+{
+public:
+    explicit AvatarProvider(QMatrixClient::Connection* conn);
+    QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize);
+
+private:
+    QMatrixClient::Connection* connection;
+};
+
+#endif // AVATARPROVIDER_H

--- a/uMatriks/models/imageprovider.cpp
+++ b/uMatriks/models/imageprovider.cpp
@@ -1,0 +1,70 @@
+#include "imageprovider.h"
+
+#include "lib/connection.h"
+#include "lib/jobs/mediathumbnailjob.h"
+
+#include <QtCore/QDebug>
+
+ImageProvider::ImageProvider(QMatrixClient::Connection* connection)
+    : QQuickImageProvider(QQmlImageProviderBase::Pixmap, QQmlImageProviderBase::ForceAsynchronousImageLoading)
+    , m_connection(connection)
+{
+    qRegisterMetaType<QPixmap*>();
+    qRegisterMetaType<QWaitCondition*>();
+}
+
+QPixmap ImageProvider::requestPixmap(const QString& id,
+                                     QSize* size, const QSize& requestedSize)
+{
+    QMutexLocker locker(&m_mutex);
+    qDebug() << "ImageProvider::requestPixmap:" << id;
+
+    QWaitCondition condition;
+    QPixmap result;
+    QMetaObject::invokeMethod(this, "doRequest", Qt::QueuedConnection,
+                              Q_ARG(QString, id), Q_ARG(QSize, requestedSize),
+                              Q_ARG(QPixmap*, &result),
+                              Q_ARG(QWaitCondition*, &condition));
+    condition.wait(&m_mutex);
+
+    if( size != nullptr )
+    {
+        *size = result.size();
+    }
+
+    return result;
+}
+
+void ImageProvider::setConnection(const QMatrixClient::Connection* connection)
+{
+    QMutexLocker locker(&m_mutex);
+
+    m_connection = connection;
+}
+
+void ImageProvider::doRequest(QString id, QSize requestedSize, QPixmap* pixmap,
+                              QWaitCondition* condition)
+{
+    Q_ASSERT(pixmap);
+    Q_ASSERT(condition);
+    QMutexLocker locker(&m_mutex);
+    if( !m_connection )
+    {
+        qDebug() << "ImageProvider::requestPixmap: no connection!";
+        *pixmap = QPixmap();
+        condition->wakeAll();
+        return;
+    }
+
+    auto job = m_connection->getThumbnail(QUrl(id), requestedSize.expandedTo({100,100}));
+    connect( job, &QMatrixClient::MediaThumbnailJob::success, this, [=]()
+    {
+        // No need to lock because we don't deal with the ImageProvider state
+        qDebug() << "gotImage";
+
+        *pixmap =
+            job->thumbnail().scaled(requestedSize,
+                                    Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        condition->wakeAll();
+    } );
+}

--- a/uMatriks/models/imageprovider.h
+++ b/uMatriks/models/imageprovider.h
@@ -1,0 +1,34 @@
+#ifndef IMAGEPROVIDER_H
+#define IMAGEPROVIDER_H
+
+#include <QtQuick/QQuickImageProvider>
+#include <QtCore/QMutex>
+#include <QtCore/QWaitCondition>
+
+namespace QMatrixClient {
+    class Connection;
+}
+
+class ImageProvider: public QObject, public QQuickImageProvider
+{
+        Q_OBJECT
+    public:
+        explicit ImageProvider(QMatrixClient::Connection* connection);
+
+        QPixmap requestPixmap(const QString& id, QSize* size,
+                              const QSize& requestedSize) override;
+
+        void setConnection(const QMatrixClient::Connection* connection);
+
+    private:
+        Q_INVOKABLE void doRequest(QString id, QSize requestedSize,
+                                   QPixmap* pixmap, QWaitCondition* condition);
+
+        const QMatrixClient::Connection* m_connection;
+        QMutex m_mutex;
+};
+
+Q_DECLARE_METATYPE(QPixmap*)
+Q_DECLARE_METATYPE(QWaitCondition*)
+
+#endif // IMAGEPROVIDER_H

--- a/uMatriks/uMatriks.pro
+++ b/uMatriks/uMatriks.pro
@@ -9,7 +9,9 @@ include(lib/libqmatrixclient.pri)
 
 SOURCES += main.cpp \
     models/roomlistmodel.cpp \
-    models/messageeventmodel.cpp
+    models/messageeventmodel.cpp \
+    models/imageprovider.cpp #\
+#    models/avatarprovider.cpp
 
 RESOURCES += uMatriks.qrc
 
@@ -57,4 +59,6 @@ DISTFILES += \
 
 HEADERS += \
     models/roomlistmodel.h \
-    models/messageeventmodel.h
+    models/messageeventmodel.h \
+    models/imageprovider.h \
+    models/avatarprovider.h


### PR DESCRIPTION
This adds supports for showing images sent over the matrix network, with this the connection has been moved as cpp varable and gets exposed to qml 

The images are still a bit small, i'm not 100% what causes this.

This also makes any other events then "messags" show in smaller text out of a bubble  

Work in progress:
- Create avatarProvider 
- download contents 
- "press to see bigger image"

![umat1](https://user-images.githubusercontent.com/1642635/29010814-58e2dc00-7b2e-11e7-8943-6fd358d7ec4a.png)
![umat-img](https://user-images.githubusercontent.com/1642635/29010815-58e3a054-7b2e-11e7-87e5-6782997b3b8f.png)
